### PR TITLE
updating styling for lie icon to superscript position

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -95,6 +95,7 @@ body {
 .letter-container.lie-close::after,
 .letter-container.lie-wrong::after {
     right: 0.15rem;
+    top: 3rem;
 }
 
 .letter-container.correct::before,


### PR DESCRIPTION
moving lie icon to superscript position will prevent it from being next to the actual icon placement of the next letter and being visually confusing to the user